### PR TITLE
Fix datomic-mysql transfer example.

### DIFF
--- a/datomic-mysql-transfer/project.clj
+++ b/datomic-mysql-transfer/project.clj
@@ -1,14 +1,14 @@
-(defproject datomic-mysql-transfer "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject datomic-mysql-transfer "0.1.0"
+  :description "Sample: Mysql to Datomic transfer"
+  :url "http://onyxplatform.org"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/java.jdbc "0.3.3"]
+                 [org.clojure/java.jdbc "0.4.2"]
                  [com.datomic/datomic-free "0.9.5173"]
-                 [org.onyxplatform/onyx "0.8.0-alpha1"]
-                 [org.onyxplatform/onyx-datomic "0.7.0"]
-                 [org.onyxplatform/onyx-sql "0.7.0"]
+                 [org.onyxplatform/onyx "0.8.0"]
+                 [org.onyxplatform/onyx-datomic "0.8.0.1"]
+                 [org.onyxplatform/onyx-sql "0.8.0.1"]
                  [com.mchange/c3p0 "0.9.2.1"]
-                 [mysql/mysql-connector-java "5.1.25"]
+                 [mysql/mysql-connector-java "5.1.27"]
                  [honeysql "0.4.3"]])

--- a/datomic-mysql-transfer/src/datomic_mysql_transfer/core.clj
+++ b/datomic-mysql-transfer/src/datomic_mysql_transfer/core.clj
@@ -156,7 +156,7 @@
 
 (def catalog
   [{:onyx/name :partition-keys
-    :onyx/plugin :sql/partition-keys
+    :onyx/plugin :onyx.plugin.sql/partition-keys
     :onyx/type :input
     :onyx/medium :sql
     :sql/classname classname
@@ -191,7 +191,7 @@
     :onyx/doc "Semantically transform the SQL rows to Datomic datoms"}
 
    {:onyx/name :write-to-datomic
-    :onyx/plugin :datomic/commit-bulk-tx
+    :onyx/plugin :onyx.plugin.datomic/write-bulk-datoms
     :onyx/type :output
     :onyx/medium :datomic
     :datomic/uri db-uri
@@ -212,7 +212,7 @@
    {:lifecycle/task :read-rows
     :lifecycle/calls :onyx.plugin.sql/read-rows-calls}
    {:lifecycle/task :write-to-datomic
-    :lifecycle/calls :onyx.plugin.datomic/write-tx-calls}])
+    :lifecycle/calls :onyx.plugin.datomic/write-bulk-tx-calls}])
 
 ;;; And off we go!
 (def job-id
@@ -261,7 +261,7 @@
 
 (def catalog
   [{:onyx/name :read-datoms
-    :onyx/plugin :datomic/read-datoms
+    :onyx/plugin :onyx.plugin.datomic/read-datoms
     :onyx/type :input
     :onyx/medium :datomic
     :datomic/uri db-uri
@@ -282,7 +282,7 @@
     :onyx/doc "Semantically transform the Datomic datoms to SQL rows"}
 
    {:onyx/name :write-to-mysql
-    :onyx/plugin :sql/write-rows
+    :onyx/plugin :onyx.plugin.sql/write-rows
     :onyx/type :output
     :onyx/medium :sql
     :sql/classname classname


### PR DESCRIPTION
Fixes some namespace issues with the datomic-mysql example and also updates the version numbers from the recent releases.

There is still a minor issue/warning after its done running ...

user=> (use 'datomic-mysql-transfer.core)
WARNING: update already refers to: #'clojure.core/update in namespace: honeysql.helpers, being replaced by: #'honeysql.helpers/update
"Datomic..."
({:user/name "Amanda", :user/age 25}
 {:user/name "Steven", :user/age 30}
 {:user/name "Mike", :user/age 23}
 {:user/name "Dorrene", :user/age 24}
 {:user/name "Bridget", :user/age 32}
 {:user/name "Joe", :user/age 70})

"MySQL..."
({:name "Mike", :age 23}
 {:name "Dorrene", :age 24}
 {:name "Bridget", :age 32}
 {:name "Joe", :age 70}
 {:name "Amanda", :age 25}
 {:name "Steven", :age 30})
nil
Exception updating the ns-cache #error {
 :cause Task clojure.lang.Agent$Action@6d4d3a16 rejected from java.util.concurrent.ThreadPoolExecutor@42bac0f5[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 3]
 :via
 [{:type java.util.concurrent.RejectedExecutionException
   :message Task clojure.lang.Agent$Action@6d4d3a16 rejected from java.util.concurrent.ThreadPoolExecutor@42bac0f5[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 3]
   :at [java.util.concurrent.ThreadPoolExecutor$AbortPolicy rejectedExecution ThreadPoolExecutor.java 2047]}]
 :trace
 [[java.util.concurrent.ThreadPoolExecutor$AbortPolicy rejectedExecution ThreadPoolExecutor.java 2047]
  [java.util.concurrent.ThreadPoolExecutor reject ThreadPoolExecutor.java 823]
  [java.util.concurrent.ThreadPoolExecutor execute ThreadPoolExecutor.java 1369]
  [clojure.lang.Agent$Action execute Agent.java 90]
  [clojure.lang.Agent enqueue Agent.java 268]
  [clojure.lang.Agent dispatchAction Agent.java 255]
  [clojure.lang.Agent dispatch Agent.java 241]
  [clojure.core$send_via doInvoke core.clj 1995]
  [clojure.lang.RestFn applyTo RestFn.java 146]
  [clojure.core$apply invoke core.clj 636]
  [clojure.core$send doInvoke core.clj 2006]
  [clojure.lang.RestFn invoke RestFn.java 490]
  [cider.nrepl.middleware.track_state$make_transport$reify__7873 send track_state.clj 188]
  [clojure.tools.nrepl.middleware.interruptible_eval$interruptible_eval$fn__665$fn__668 invoke interruptible_eval.clj 192]
  [clojure.tools.nrepl.middleware.interruptible_eval$run_next$fn__660 invoke interruptible_eval.clj 159]
  [clojure.lang.AFn run AFn.java 22]
  [java.util.concurrent.ThreadPoolExecutor runWorker ThreadPoolExecutor.java 1142]
  [java.util.concurrent.ThreadPoolExecutor$Worker run ThreadPoolExecutor.java 617]
  [java.lang.Thread run Thread.java 745]]}
